### PR TITLE
Remove smart data dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,8 +6,3 @@ package simple-algebra
     -Wincomplete-record-updates -Wincomplete-uni-patterns
     -Wmissing-home-modules -Wmissing-export-lists -Wpartial-fields
     -Wredundant-constraints
-
-source-repository-package
-    type: git
-    location: https://github.com/tbidne/smart-data.git
-    tag: d5fb832226519ca826c33462bf5ccf4b84645f54

--- a/flake.lock
+++ b/flake.lock
@@ -33,31 +33,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "smart-data-src": "smart-data-src"
-      }
-    },
-    "smart-data-src": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1635632814,
-        "narHash": "sha256-DbMvLyC2ufSrRCzLvwK/RPcDCwK0jQmdypadRRBRaQY=",
-        "owner": "tbidne",
-        "repo": "smart-data",
-        "rev": "d5fb832226519ca826c33462bf5ccf4b84645f54",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tbidne",
-        "repo": "smart-data",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,16 +2,10 @@
   description = "simple-algebra flake";
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.smart-data-src = {
-    url = "github:tbidne/smart-data";
-    inputs.nixpkgs.follows = "nixpkgs";
-    inputs.flake-utils.follows = "flake-utils";
-  };
   outputs =
     { flake-utils
     , nixpkgs
     , self
-    , smart-data-src
     }:
     flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
     let
@@ -36,9 +30,6 @@
               pkgs.nixpkgs-fmt
               pkgs.zlib
             ]);
-          overrides = final: prev: with pkgs.haskellPackages; {
-            smart-data = final.callCabal2nix "smart-data" smart-data-src { };
-          };
         };
     in
     {

--- a/simple-algebra.cabal
+++ b/simple-algebra.cabal
@@ -27,12 +27,15 @@ source-repository head
 
 common common-exts
   default-extensions:
+    DataKinds
     FlexibleInstances
     FunctionalDependencies
     ImportQualifiedPost
     MultiParamTypeClasses
     PatternSynonyms
     ScopedTypeVariables
+    StandaloneKindSignatures
+    TypeApplications
 
 library
   import:           common-exts
@@ -49,10 +52,8 @@ library
     Simple.Algebra.Semiring
     Simple.Algebra.VectorSpace
     Simple.Literal
+    Simple.NonNat
 
-  build-depends:
-    , base        ^>=4.14.0.0
-    , smart-data  ^>=0.1.0.0
-
+  build-depends:    base ^>=4.14.0.0
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/src/Simple/Algebra/Additive.hs
+++ b/src/Simple/Algebra/Additive.hs
@@ -8,12 +8,7 @@ import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Ratio (Ratio)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Natural (Natural)
-import Smart.Data.Math.Negative (Negative (..), unsafeNegative)
-import Smart.Data.Math.NonNegative (NonNegative (..), unsafeNonNegative)
-import Smart.Data.Math.NonOne (NonOne (..), unsafeNonOne)
-import Smart.Data.Math.NonPositive (NonPositive (..), unsafeNonPositive)
-import Smart.Data.Math.NonZero (NonZero (..), unsafeNonZero)
-import Smart.Data.Math.Positive (Positive (..), unsafePositive)
+import Simple.NonNat (NonZero, unsafeNonZero, pattern MkNonZero)
 
 -- | Defines an additive semigroup.
 class Eq g => Additive g where
@@ -66,18 +61,6 @@ instance Additive Word64 where
 instance Integral a => Additive (Ratio a) where
   (.+.) = (+)
 
-instance (Num a, Ord a) => Additive (Negative a) where
-  MkNegative x .+. MkNegative y = unsafeNegative $ x + y
-
-instance (Num a, Ord a) => Additive (NonNegative a) where
-  MkNonNegative x .+. MkNonNegative y = unsafeNonNegative $ x + y
-
-instance (Num a, Ord a) => Additive (NonPositive a) where
-  MkNonPositive x .+. MkNonPositive y = unsafeNonPositive $ x + y
-
-instance (Num a, Ord a) => Additive (Positive a) where
-  MkPositive x .+. MkPositive y = unsafePositive $ x + y
-
 instance Additive (NonZero Natural) where
   MkNonZero x .+. MkNonZero y = unsafeNonZero $ x + y
 
@@ -95,21 +78,3 @@ instance Additive (NonZero Word32) where
 
 instance Additive (NonZero Word64) where
   MkNonZero x .+. MkNonZero y = unsafeNonZero $ x + y
-
-instance Additive (NonOne Natural) where
-  MkNonOne x .+. MkNonOne y = unsafeNonOne $ x + y
-
-instance Additive (NonOne Word) where
-  MkNonOne x .+. MkNonOne y = unsafeNonOne $ x + y
-
-instance Additive (NonOne Word8) where
-  MkNonOne x .+. MkNonOne y = unsafeNonOne $ x + y
-
-instance Additive (NonOne Word16) where
-  MkNonOne x .+. MkNonOne y = unsafeNonOne $ x + y
-
-instance Additive (NonOne Word32) where
-  MkNonOne x .+. MkNonOne y = unsafeNonOne $ x + y
-
-instance Additive (NonOne Word64) where
-  MkNonOne x .+. MkNonOne y = unsafeNonOne $ x + y

--- a/src/Simple/Algebra/AdditiveMonoid.hs
+++ b/src/Simple/Algebra/AdditiveMonoid.hs
@@ -1,9 +1,6 @@
 -- | Provides the 'AdditiveMonoid' typeclass.
 module Simple.Algebra.AdditiveMonoid
   ( AdditiveMonoid (..),
-    NonZero (MkNonZero, unNonZero),
-    mkMonoidNonZero,
-    unsafeMonoidNonZero,
   )
 where
 
@@ -12,11 +9,6 @@ import Data.Ratio (Ratio)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Natural (Natural)
 import Simple.Algebra.Additive (Additive (..))
-import Smart.Data.Math.NonNegative (NonNegative (..), unsafeNonNegative)
-import Smart.Data.Math.NonOne (NonOne (..), unsafeNonOne)
-import Smart.Data.Math.NonPositive (NonPositive (..), unsafeNonPositive)
-import Smart.Data.Math.NonZero (NonZero (..))
-import Unsafe.Coerce (unsafeCoerce)
 
 -- | Defines a monoid over an \"additive\" semigroup.
 class Additive g => AdditiveMonoid g where
@@ -66,40 +58,3 @@ instance AdditiveMonoid Word64 where
 
 instance Integral a => AdditiveMonoid (Ratio a) where
   zero = 0
-
-instance (Num a, Ord a) => AdditiveMonoid (NonNegative a) where
-  zero = unsafeNonNegative 0
-
-instance (Num a, Ord a) => AdditiveMonoid (NonPositive a) where
-  zero = unsafeNonPositive 0
-
-instance AdditiveMonoid (NonOne Natural) where
-  zero = unsafeNonOne 0
-
-instance AdditiveMonoid (NonOne Word) where
-  zero = unsafeNonOne 0
-
-instance AdditiveMonoid (NonOne Word8) where
-  zero = unsafeNonOne 0
-
-instance AdditiveMonoid (NonOne Word16) where
-  zero = unsafeNonOne 0
-
-instance AdditiveMonoid (NonOne Word32) where
-  zero = unsafeNonOne 0
-
-instance AdditiveMonoid (NonOne Word64) where
-  zero = unsafeNonOne 0
-
--- | Smart constructor for 'NonZero', based on its 'zero'.
-mkMonoidNonZero :: AdditiveMonoid a => a -> Maybe (NonZero a)
-mkMonoidNonZero x
-  | x == zero = Nothing
-  | otherwise = Just (unsafeCoerce x)
-
--- | Unsafe constructor for 'NonZero', based on its 'zero'. Intended to be used
--- with known constants. Exercise restraint!
-unsafeMonoidNonZero :: AdditiveMonoid a => a -> NonZero a
-unsafeMonoidNonZero x
-  | x == zero = error "Passed identity to unsafeMonoidNonZero!"
-  | otherwise = unsafeCoerce x

--- a/src/Simple/Algebra/Field.hs
+++ b/src/Simple/Algebra/Field.hs
@@ -1,17 +1,20 @@
 -- | Provides the 'Field' typeclass.
 module Simple.Algebra.Field
-  ( Field (..),
-    NonZero (MkNonZero, unNonZero),
-    AM.mkMonoidNonZero,
-    AM.unsafeMonoidNonZero,
+  ( -- * Typeclass
+    Field (..),
+
+    -- * NonZero
+    mkFieldNonZero,
+    unsafeFieldNonZero,
   )
 where
 
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Ratio (Ratio)
-import Simple.Algebra.AdditiveMonoid (NonZero (..))
-import Simple.Algebra.AdditiveMonoid qualified as AM
+import Simple.Algebra.AdditiveMonoid (AdditiveMonoid (..))
 import Simple.Algebra.Ring (Ring)
+import Simple.NonNat (NonZero, pattern MkNonZero)
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | Defines a field.
 class Ring f => Field f where
@@ -37,3 +40,16 @@ instance Field Integer where x .%. MkNonZero d = x `div` d
 
 instance Integral k => Field (Ratio k) where
   x .%. MkNonZero d = x / d
+
+-- | Smart constructor for 'NonZero', based on its additive monoid instance.
+mkFieldNonZero :: Field a => a -> Maybe (NonZero a)
+mkFieldNonZero x
+  | x == zero = Nothing
+  | otherwise = Just (unsafeCoerce x)
+
+-- | Unsafe constructor for 'NonZero', based on its additive monoid instance.
+-- Intended to be used with known constants. Exercise restraint!
+unsafeFieldNonZero :: Field a => a -> NonZero a
+unsafeFieldNonZero x
+  | x == zero = error "Passed identity to unsafeFieldNonZero!"
+  | otherwise = unsafeCoerce x

--- a/src/Simple/Algebra/Multiplicative.hs
+++ b/src/Simple/Algebra/Multiplicative.hs
@@ -8,9 +8,7 @@ import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Ratio (Ratio)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Natural (Natural)
-import Smart.Data.Math.NonNegative (NonNegative (..), unsafeNonNegative)
-import Smart.Data.Math.NonZero (NonZero (..), unsafeNonZero)
-import Smart.Data.Math.Positive (Positive (..), unsafePositive)
+import Simple.NonNat (NonZero, unsafeNonZero, pattern MkNonZero)
 
 -- | Defines a multiplicative semigroup.
 class Eq g => Multiplicative g where
@@ -62,12 +60,6 @@ instance Multiplicative Word64 where
 
 instance Integral a => Multiplicative (Ratio a) where
   (.*.) = (*)
-
-instance (Num a, Ord a) => Multiplicative (NonNegative a) where
-  MkNonNegative x .*. MkNonNegative y = unsafeNonNegative $ x * y
-
-instance (Num a, Ord a) => Multiplicative (Positive a) where
-  MkPositive x .*. MkPositive y = unsafePositive $ x * y
 
 instance (Num a, Ord a) => Multiplicative (NonZero a) where
   MkNonZero x .*. MkNonZero y = unsafeNonZero $ x * y

--- a/src/Simple/Algebra/MultiplicativeMonoid.hs
+++ b/src/Simple/Algebra/MultiplicativeMonoid.hs
@@ -1,9 +1,6 @@
 -- | Provides the 'MultiplicativeMonoid' typeclass.
 module Simple.Algebra.MultiplicativeMonoid
   ( MultiplicativeMonoid (..),
-    NonOne (MkNonOne, unNonOne),
-    mkMonoidNonOne,
-    unsafeMonoidNonOne,
   )
 where
 
@@ -12,10 +9,7 @@ import Data.Ratio (Ratio)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Natural (Natural)
 import Simple.Algebra.Multiplicative (Multiplicative (..))
-import Smart.Data.Math.NonNegative (NonNegative (..), unsafeNonNegative)
-import Smart.Data.Math.NonOne (NonOne (..))
-import Smart.Data.Math.Positive (Positive (..), unsafePositive)
-import Unsafe.Coerce (unsafeCoerce)
+import Simple.NonNat (NonZero, unsafeNonZero)
 
 -- | Defines a monoid over a \"multiplicative\" semigroup.
 class Multiplicative g => MultiplicativeMonoid g where
@@ -66,21 +60,5 @@ instance MultiplicativeMonoid Word64 where
 instance Integral a => MultiplicativeMonoid (Ratio a) where
   one = 1
 
-instance (Num a, Ord a) => MultiplicativeMonoid (NonNegative a) where
-  one = unsafeNonNegative 1
-
-instance (Num a, Ord a) => MultiplicativeMonoid (Positive a) where
-  one = unsafePositive 1
-
--- | Smart constructor for 'NonOne', based on its 'one'.
-mkMonoidNonOne :: MultiplicativeMonoid a => a -> Maybe (NonOne a)
-mkMonoidNonOne x
-  | x == one = Nothing
-  | otherwise = Just (unsafeCoerce x)
-
--- | Unsafe constructor for 'NonOne', based on its 'one'. Intended to be used
--- with known constants. Exercise restraint!
-unsafeMonoidNonOne :: MultiplicativeMonoid a => a -> NonOne a
-unsafeMonoidNonOne x
-  | x == one = error "Passed identity to unsafeMonoidNonOne!"
-  | otherwise = unsafeCoerce x
+instance (Num a, Ord a) => MultiplicativeMonoid (NonZero a) where
+  one = unsafeNonZero 1

--- a/src/Simple/Algebra/Semiring.hs
+++ b/src/Simple/Algebra/Semiring.hs
@@ -10,7 +10,6 @@ import Data.Word (Word16, Word32, Word64, Word8)
 import Numeric.Natural (Natural)
 import Simple.Algebra.AdditiveMonoid (AdditiveMonoid (..))
 import Simple.Algebra.MultiplicativeMonoid (MultiplicativeMonoid (..))
-import Smart.Data.Math.NonNegative (NonNegative)
 
 -- | Defines a semiring.
 class (AdditiveMonoid r, MultiplicativeMonoid r) => Semiring r
@@ -44,5 +43,3 @@ instance Semiring Word32
 instance Semiring Word64
 
 instance Integral a => Semiring (Ratio a)
-
-instance Integral a => Semiring (NonNegative a)

--- a/src/Simple/Algebra/VectorSpace.hs
+++ b/src/Simple/Algebra/VectorSpace.hs
@@ -1,15 +1,12 @@
 -- | Provides the 'VectorSpace' typeclass.
 module Simple.Algebra.VectorSpace
   ( VectorSpace (..),
-    NonZero (MkNonZero, unNonZero),
-    F.mkMonoidNonZero,
-    F.unsafeMonoidNonZero,
   )
 where
 
-import Simple.Algebra.Field (Field (..), NonZero (..))
-import Simple.Algebra.Field qualified as F
+import Simple.Algebra.Field (Field (..))
 import Simple.Algebra.Module (Module (..))
+import Simple.NonNat (NonZero)
 
 -- | Defines a vector space over a field. Ideally, this class need
 -- not include any functions. The only difference between a 'Module'

--- a/src/Simple/NonNat.hs
+++ b/src/Simple/NonNat.hs
@@ -1,0 +1,85 @@
+-- | Provides the 'NonNat' type for enforcing a "Not n" invariant.
+module Simple.NonNat
+  ( NonNat (MkNonNat, unNonNat),
+    mkNonNat,
+    unsafeNonNat,
+
+    -- * NonZero
+    NonZero,
+    pattern MkNonZero,
+    unNonZero,
+    mkNonZero,
+    unsafeNonZero,
+  )
+where
+
+import Data.Kind (Type)
+import Data.Proxy (Proxy (..))
+import GHC.TypeNats (KnownNat, Nat, natVal)
+
+-- | Newtype wrapper over /a/ which excludes some 'Nat' /x/. That is,
+-- @NonNat x a@ is some \(n \in a \) such that \(n \neq x\).
+type NonNat :: Nat -> Type -> Type
+newtype NonNat x a = MkUnsafeNonNat
+  { -- | Unwraps the 'NonNat'
+    unNonNat :: a
+  }
+  deriving (Eq, Ord, Show)
+
+-- | Allows pattern matching on 'NonNat'.
+pattern MkNonNat :: a -> NonNat x a
+pattern MkNonNat n <- MkUnsafeNonNat n
+
+{-# COMPLETE MkNonNat #-}
+
+-- | Constructs a 'NonNat'.
+--
+-- >>> mkNonNat @0 50
+-- Just (MkUnsafeNonNat {unNonNat = 50})
+--
+-- >>> mkNonNat @50 50
+-- Nothing
+mkNonNat :: forall x a. (Eq a, KnownNat x, Num a) => a -> Maybe (NonNat x a)
+mkNonNat n
+  | n /= excluded = Just $ MkUnsafeNonNat n
+  | otherwise = Nothing
+  where
+    excluded = fromInteger $ toInteger $ natVal $ Proxy @x
+
+-- | Unsafe constructor for 'NonNat', intended to be used with
+-- known constants, e.g. @unsafeNonNat \@0 50@. Exercise restraint!
+unsafeNonNat :: forall x a. (Eq a, KnownNat x, Num a) => a -> NonNat x a
+unsafeNonNat n
+  | n /= excluded = MkUnsafeNonNat n
+  | otherwise = error $ "Passed invalid NonNat: " <> show excludedNat
+  where
+    excludedNat = natVal $ Proxy @x
+    excluded = fromIntegral excludedNat
+
+-- | NonNat for 0.
+type NonZero = NonNat 0
+
+-- | Allows pattern matching on 'NonZero'.
+pattern MkNonZero :: a -> NonZero a
+pattern MkNonZero n <- MkUnsafeNonNat n
+
+-- | Unwraps the NonZero.
+unNonZero :: NonZero a -> a
+unNonZero (MkNonZero n) = n
+
+{-# COMPLETE MkNonZero #-}
+
+-- | Constructs a 'NonZero'.
+--
+-- >>> mkNonZero 50
+-- Just (MkUnsafeNonNat {unNonNat = 50})
+--
+-- >>> mkNonZero 0
+-- Nothing
+mkNonZero :: (Eq a, Num a) => a -> Maybe (NonNat 0 a)
+mkNonZero = mkNonNat @0
+
+-- | Unsafe constructor for 'NonZero', intended to be used with
+-- known constants, e.g. @unsafeNonZero 50@. Exercise restraint!
+unsafeNonZero :: (Eq a, Num a) => a -> NonNat 0 a
+unsafeNonZero = unsafeNonNat @0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,3 @@ resolver:
   url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/13.yaml
 packages:
 - .
-
-extra-deps:
-- git: https://github.com/tbidne/smart-data.git
-  commit: d5fb832226519ca826c33462bf5ccf4b84645f54


### PR DESCRIPTION
We will instead have smart-data depend on this package. This arguably
makes more sense: smart-data benefits from algebra's instances more than
the reverse. The reason we had algebra depend on smart-data in the first
place was for the NonZero type. Instead we will include that type here and
reverse the dependency.